### PR TITLE
ci: add PR test workflow + SHA-pin all actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+# agent-notes: { ctx: "CI workflow — build and test on PRs", deps: [release.yml], state: active, last: "ines@2026-03-14" }
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore -c Release
+
+      - name: Install Playwright
+        run: pwsh src/Md2.Cli/bin/Release/net9.0/.playwright/node/install.ps1
+
+      - name: Test
+        run: dotnet test --no-build -c Release --logger "trx;LogFileName=results.trx"
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: test-results
+          path: '**/results.trx'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,10 +30,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
         with:
           dotnet-version: '9.0.x'
 
@@ -56,7 +56,7 @@ jobs:
         run: Compress-Archive -Path publish/${{ matrix.artifact }}/* -DestinationPath ${{ matrix.artifact }}.zip
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}.*
@@ -66,10 +66,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: artifacts
 


### PR DESCRIPTION
## Summary
- New CI workflow runs `dotnet build` + `dotnet test` on every PR to `main`
- All GitHub Actions SHA-pinned to prevent supply chain attacks (both CI and release workflows)
- Concurrency control cancels stale runs when new commits are pushed
- 15-minute job timeout prevents resource abuse from hanging tests
- `persist-credentials: false` on checkout for hygiene

## Security notes (Pierrot review)
- Uses `pull_request` trigger (not `pull_request_target`) — fork PRs get read-only token, no secret access
- `permissions: contents: read` is minimal
- No secrets referenced in CI workflow
- **Repo setting recommended:** Enable "Require approval for all outside collaborators" under Settings > Actions > General

## Test plan
- [ ] Merge this PR and verify CI triggers on a subsequent PR
- [ ] Verify release workflow still works on next `v*` tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)