### PR TITLE
fix(emit-docx): Mermaid diagrams not embedding when base directory is set

### DIFF
--- a/src/Md2.Emit.Docx/DocxAstVisitor.cs
+++ b/src/Md2.Emit.Docx/DocxAstVisitor.cs
@@ -382,8 +382,9 @@ public class DocxAstVisitor
         var mermaidPath = codeBlock.GetMermaidImagePath();
         if (mermaidPath != null && File.Exists(mermaidPath))
         {
-            // Empty alt text suppresses visible caption; "Mermaid diagram" used only as DocProperties.Description
-            var imageParagraphs = _imageBuilder.BuildImage(_mainDocumentPart, mermaidPath, "", _theme, _baseDirectory);
+            // Mermaid images are rendered by us to an absolute cache path — skip path traversal check
+            // by passing null for baseDirectory (the file is trusted, not user-supplied)
+            var imageParagraphs = _imageBuilder.BuildImage(_mainDocumentPart, mermaidPath, "", _theme, baseDirectory: null);
             return imageParagraphs.ToArray<OpenXmlElement>();
         }
 

--- a/tests/Md2.Integration.Tests/InlineImageAndMermaidCaptionTests.cs
+++ b/tests/Md2.Integration.Tests/InlineImageAndMermaidCaptionTests.cs
@@ -64,7 +64,7 @@ public class InlineImageAndMermaidCaptionTests : IDisposable
     }
 
     private async Task<(WordprocessingDocument Doc, MemoryStream Stream)> RunFullPipelineWithAstMutation(
-        string markdown, Action<MarkdownDocument> mutateAst)
+        string markdown, Action<MarkdownDocument> mutateAst, string? inputBaseDirectory = null)
     {
         var pipeline = new ConversionPipeline();
         var parserOptions = new ParserOptions();
@@ -78,7 +78,7 @@ public class InlineImageAndMermaidCaptionTests : IDisposable
         mutateAst(transformResult.Document);
 
         var theme = ResolvedTheme.CreateDefault();
-        var emitOptions = new EmitOptions();
+        var emitOptions = new EmitOptions { InputBaseDirectory = inputBaseDirectory };
         var emitter = new DocxEmitter();
         var stream = new MemoryStream();
 
@@ -272,6 +272,57 @@ public class InlineImageAndMermaidCaptionTests : IDisposable
             // A caption would contain the alt text — which for mermaid is empty, so
             // we verify no "mermaid" text appears in the next paragraph
             nextText.ToLowerInvariant().ShouldNotContain("mermaid");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Regression: Mermaid images must embed even when InputBaseDirectory is set
+    // The path safety check must not reject absolute cache paths for images
+    // we rendered ourselves.
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task MermaidBlock_EmbedsImage_WhenInputBaseDirectoryIsSet()
+    {
+        var imagePath = CreateTempPng(); // absolute path in /tmp
+        var markdown = "```mermaid\ngraph TD;\n    A-->B;\n```\n";
+
+        // Use a different directory as base — simulates real CLI usage where
+        // the input .md file lives in a project directory, not /tmp
+        var baseDir = Path.Combine(Path.GetTempPath(), $"md2test_base_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(baseDir);
+
+        try
+        {
+            var (wordDoc, stream) = await RunFullPipelineWithAstMutation(
+                markdown,
+                doc =>
+                {
+                    var fencedBlock = doc.Descendants<FencedCodeBlock>()
+                        .FirstOrDefault(b => b.Info == "mermaid");
+                    fencedBlock.ShouldNotBeNull();
+                    fencedBlock!.SetMermaidImagePath(imagePath);
+                },
+                inputBaseDirectory: baseDir);
+
+            using var __ = stream;
+            using var _ = wordDoc;
+
+            var body = wordDoc.MainDocumentPart!.Document.Body!;
+
+            // The image should be embedded as a Drawing, not replaced with a placeholder
+            var drawings = body.Descendants<Drawing>().ToList();
+            drawings.ShouldNotBeEmpty(
+                "Mermaid diagram should embed as a Drawing even when InputBaseDirectory is set");
+
+            // Verify no placeholder text was emitted
+            var allText = string.Join(" ", body.Descendants<Text>().Select(t => t.Text));
+            allText.ShouldNotContain("Image not found");
+        }
+        finally
+        {
+            try { Directory.Delete(baseDir, true); }
+            catch { /* best-effort cleanup */ }
         }
     }
 


### PR DESCRIPTION
## Summary
- **Bug:** The `IsPathSafe` security check (added in f333654) rejects absolute paths. Mermaid diagrams are rendered to `/tmp/md2-cache/` (absolute). When `InputBaseDirectory` is set (always in real CLI usage), Mermaid images silently fall through to a placeholder instead of embedding.
- **Fix:** Pass `baseDirectory: null` for Mermaid images in `DocxAstVisitor.VisitFencedCodeBlock`, since these are trusted images we rendered ourselves — not user-supplied paths.
- **Regression test:** New test sets `InputBaseDirectory` to a different directory and verifies Mermaid diagrams still produce `Drawing` elements. Confirmed the test fails without the fix.

## Root cause analysis
The existing Mermaid integration tests used `EmitOptions` without setting `InputBaseDirectory`, which meant the path safety check was never triggered. Real CLI usage always sets it. The security fix was tested in isolation (`IsPathSafe` unit tests) but not in combination with the Mermaid rendering path.

## Test plan
- [x] New test `MermaidBlock_EmbedsImage_WhenInputBaseDirectoryIsSet` passes with fix
- [x] Same test fails without fix (verified by temporarily reverting)
- [x] All 8 existing `InlineImageAndMermaidCaptionTests` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)