### PR TITLE
fix(ci): use Playwright CLI for Chromium install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         run: dotnet build --no-restore -c Release
 
       - name: Install Playwright
-        run: pwsh src/Md2.Cli/bin/Release/net9.0/.playwright/node/install.ps1
+        run: dotnet tool install --global Microsoft.Playwright.CLI && playwright install chromium --with-deps
 
       - name: Test
         run: dotnet test --no-build -c Release --logger "trx;LogFileName=results.trx"


### PR DESCRIPTION
## Summary
- The `pwsh` install script path (`src/Md2.Cli/bin/Release/net9.0/.playwright/node/install.ps1`) doesn't exist in CI — the build output structure differs from local dev
- Switched to `dotnet tool install --global Microsoft.Playwright.CLI && playwright install chromium --with-deps` which is the recommended approach and doesn't depend on build output paths

## Test plan
- [ ] CI passes on this PR (self-testing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)