### PR TITLE
fix(diagrams): Mermaid node text invisible in dark themes (green on green)

### DIFF
--- a/src/Md2.Diagrams/MermaidThemeConfig.cs
+++ b/src/Md2.Diagrams/MermaidThemeConfig.cs
@@ -28,12 +28,10 @@ public class MermaidThemeConfig
     /// </summary>
     public static MermaidThemeConfig FromResolvedTheme(ResolvedTheme theme)
     {
-        var primaryTextColor = theme.TableHeaderForeground;
-        // Auto-derive contrast if primary color is extreme
-        if (string.IsNullOrEmpty(primaryTextColor) || primaryTextColor == "FFFFFF")
-        {
-            primaryTextColor = DeriveContrastTextColor(theme.PrimaryColor);
-        }
+        // Always derive text color for contrast against node backgrounds (PrimaryColor).
+        // Using theme.TableHeaderForeground here caused green-on-green in dark themes
+        // like hackterm where both the node background and header text are the same color.
+        var primaryTextColor = DeriveContrastTextColor(theme.PrimaryColor);
 
         var fontFamily = theme.HeadingFont;
         if (!fontFamily.Contains("sans-serif", StringComparison.OrdinalIgnoreCase))

--- a/tests/Md2.Diagrams.Tests/MermaidThemeConfigTests.cs
+++ b/tests/Md2.Diagrams.Tests/MermaidThemeConfigTests.cs
@@ -42,13 +42,35 @@ public class MermaidThemeConfigTests
     }
 
     [Fact]
-    public void FromResolvedTheme_MapsTableHeaderForegroundToPrimaryTextColor()
+    public void FromResolvedTheme_DerivesPrimaryTextColorFromPrimaryForContrast()
     {
-        var theme = new ResolvedTheme { TableHeaderForeground = "AABBCC" };
+        // PrimaryTextColor should be derived for contrast against PrimaryColor (node background),
+        // not taken from TableHeaderForeground which is unrelated to diagram rendering.
+        var theme = new ResolvedTheme { PrimaryColor = "1B3A5C" }; // dark
 
         var config = MermaidThemeConfig.FromResolvedTheme(theme);
 
-        config.PrimaryTextColor.ShouldBe("AABBCC");
+        // Dark primary → light text
+        var r = Convert.ToInt32(config.PrimaryTextColor[..2], 16);
+        r.ShouldBeGreaterThan(180);
+    }
+
+    [Fact]
+    public void FromResolvedTheme_HacktermColors_DoesNotProduceGreenOnGreen()
+    {
+        // Hackterm: primary=00CC33 (green), tableHeaderForeground=00CC33 (green).
+        // Previously this produced green text on green node backgrounds.
+        var theme = new ResolvedTheme
+        {
+            PrimaryColor = "00CC33",
+            TableHeaderForeground = "00CC33",
+        };
+
+        var config = MermaidThemeConfig.FromResolvedTheme(theme);
+
+        // Node text should NOT be the same as the node background
+        config.PrimaryTextColor.ShouldNotBe(config.PrimaryColor,
+            "Mermaid node text must contrast with node background");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- **Bug:** Hackterm theme produces green text (#00CC33) on green node backgrounds (#00CC33) in Mermaid diagrams, making text invisible
- **Root cause:** `MermaidThemeConfig.FromResolvedTheme()` used `TableHeaderForeground` as `PrimaryTextColor`. For hackterm, both are the same green as `PrimaryColor`. The contrast derivation fallback only triggered for empty or white values.
- **Fix:** Always derive `PrimaryTextColor` from `PrimaryColor` using the existing `DeriveContrastTextColor()` luminance calculation. This ensures readable text on node backgrounds regardless of theme.

## Test plan
- [x] New test `FromResolvedTheme_HacktermColors_DoesNotProduceGreenOnGreen` passes
- [x] Updated test `FromResolvedTheme_DerivesPrimaryTextColorFromPrimaryForContrast` verifies dark primary → light text
- [x] All 31 MermaidThemeConfig tests pass
- [x] Regenerated hackterm DOCX — diagram text is now visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)