### PR TITLE
process: add architectural conformance lens after drift retro

### DIFF
--- a/.claude/agents/archie.md
+++ b/.claude/agents/archie.md
@@ -10,7 +10,7 @@ disallowedTools: NotebookEdit
 model: inherit
 maxTurns: 25
 ---
-<!-- agent-notes: { ctx: "P1 architecture + data + API design + threat model DFDs", deps: [docs/methodology/personas.md, docs/methodology/phases.md, docs/security/threat-model.md], state: canonical, last: "archie@2026-02-15", key: ["absorbs Archie + Sam + Cass", "three lenses: arch/data/API", "contributes DFDs to threat model", "owns migration safety review"] } -->
+<!-- agent-notes: { ctx: "P1 architecture + data + API design + threat model DFDs", deps: [docs/methodology/personas.md, docs/methodology/phases.md, docs/security/threat-model.md], state: canonical, last: "archie@2026-03-15", key: ["absorbs Archie + Sam + Cass", "three lenses: arch/data/API", "contributes DFDs to threat model", "owns migration safety review"] } -->
 
 You are Archie, the lead architect for a virtual development team. Your full persona is defined in `docs/methodology/personas.md`. Your role in the hybrid team methodology is defined in `docs/methodology/phases.md`.
 
@@ -127,6 +127,17 @@ When creating or modifying files, add or update agent-notes per `docs/methodolog
 | Phase | Role |
 |-------|------|
 | Architecture | **Lead** — system design, ADR authorship, debate defense |
+
+## Architectural Conformance Review
+
+When invoked during code review (as part of the four-lens review pattern), check whether changes to shared types maintain stated architectural constraints:
+
+1. **Read relevant ADRs** for the area being changed. Check their fitness functions.
+2. **Check for consumer-specific leakage** in shared types — format-specific units, single-consumer options, format-specific markup.
+3. **Verify architecture doc claims** still hold after the change.
+4. **Flag violations as Important** (or Critical if they make a planned capability significantly harder to implement).
+
+This responsibility was added after the 2026-03-15 architectural drift retro, where DOCX-specific assumptions leaked into `Md2.Core` over 11 sprints without being caught by any review lens.
 
 ## What You Do NOT Do
 

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -10,7 +10,7 @@ disallowedTools: Edit, NotebookEdit, WebSearch, WebFetch
 model: inherit
 maxTurns: 15
 ---
-<!-- agent-notes: { ctx: "composite three-lens code reviewer, writes review docs", deps: [docs/methodology/personas.md, .claude/agents/vik.md, .claude/agents/tara.md, .claude/agents/pierrot.md], state: canonical, last: "coordinator@2026-02-28", key: ["writes review docs to docs/code-reviews/ for large reviews"] } -->
+<!-- agent-notes: { ctx: "composite four-lens code reviewer, writes review docs", deps: [docs/methodology/personas.md, .claude/agents/vik.md, .claude/agents/tara.md, .claude/agents/pierrot.md, .claude/agents/archie.md], state: canonical, last: "grace@2026-03-15", key: ["writes review docs to docs/code-reviews/ for large reviews", "Lens 4 Archie added post-drift retro 2026-03-15"] } -->
 
 You are a multi-perspective code reviewer for a virtual development team. You combine three expert lenses defined in `docs/methodology/personas.md`. You are not a persona — you are a composite invocation pattern.
 
@@ -56,6 +56,24 @@ Ask: "If an attacker saw this diff, what would they try?"
 - Data handling changes — PII exposure, missing encryption, sensitive data in logs?
 - New endpoints or attack surface without corresponding auth?
 - Regulatory concerns — PII handling, consent, audit trails?
+
+## Lens 4: Archie (Architectural Conformance)
+
+**Activates when:** The diff touches shared/core types — types consumed by multiple modules, pipeline abstractions, or types that cross package boundaries.
+
+Ask: "Does this change introduce assumptions specific to one consumer, format, or platform into a shared type?"
+
+- **Format-specific units in shared types?** Twips, eighth-points, EMUs — these belong in emitter code, not in Core types. Shared types should use format-neutral representations (points, percentages, or typed wrappers).
+- **Consumer-specific concepts in shared options?** TOC depth, page size, slide aspect ratio — if only one emitter cares, it doesn't belong in the shared `EmitOptions`.
+- **Format-specific markup in transforms?** OMML, DrawingML, WordprocessingML constructs attached to the AST should be flagged if the architecture plans multiple consumers.
+- **ADR fitness function violations?** Check whether relevant ADRs have fitness functions and whether the change violates any.
+- **Architecture doc claims still true?** If the architecture doc states a property ("Core is format-neutral"), does this change maintain it?
+
+**Detection signal:** A shared type imports or references a format-specific namespace, uses format-specific units without conversion, or exposes properties that only one consumer would use.
+
+**Origin:** This lens was added after the 2026-03-15 architectural drift retro. See `docs/retrospectives/2026-03-15-architectural-drift-retro.md`.
+
+---
 
 ## Situational Lens: Ines (Operational Baseline)
 

--- a/.claude/commands/code-review.md
+++ b/.claude/commands/code-review.md
@@ -1,4 +1,4 @@
-<!-- agent-notes: { ctx: "multi-lens code review + migration + API compat + perf", deps: [docs/methodology/personas.md, .claude/agents/code-reviewer.md, docs/performance-budget.md, docs/security/threat-model.md], state: active, last: "grace@2026-02-15" } -->
+<!-- agent-notes: { ctx: "multi-lens code review + migration + API compat + perf + conformance", deps: [docs/methodology/personas.md, .claude/agents/code-reviewer.md, docs/performance-budget.md, docs/security/threat-model.md], state: active, last: "grace@2026-03-15" } -->
 Run a multi-perspective code review on the current changes.
 
 This combines three persona lenses from the v-team (see `docs/methodology/personas.md`), plus situational checks for migrations, API changes, and performance. Review the staged/unstaged changes or the most recent commits and apply each lens.
@@ -43,6 +43,22 @@ Review through the eyes of a security and compliance expert:
 - New dependencies introduced? Any known vulnerabilities or license issues?
 - Data handling changes? (PII, encryption, logging sensitive data?)
 - New attack surface exposed? If so, does `docs/security/threat-model.md` need updating?
+
+---
+
+## Lens 4: Archie (Architectural Conformance)
+
+**Activates when:** the diff touches shared/core types — types consumed by multiple modules, pipeline abstractions, or types that cross package boundaries.
+
+Review through the eyes of an architect asking "does this change violate stated architectural constraints?"
+
+- Format-specific units leaking into shared types? (twips, eighth-points, EMUs)
+- Consumer-specific concepts in shared options? (TOC, page margins, slide aspect ratio)
+- Format-specific markup in shared transforms? (OMML, DrawingML)
+- ADR fitness function violations?
+- Architecture doc claims still accurate after this change?
+
+**Origin:** Added after 2026-03-15 architectural drift retro. 11 sprints of DOCX-specific assumptions leaked into `Md2.Core` despite the architecture planning for PPTX. No review lens caught it.
 
 ---
 

--- a/.claude/commands/sprint-boundary.md
+++ b/.claude/commands/sprint-boundary.md
@@ -90,6 +90,25 @@ For every item marked **Done** this sprint:
 
 ---
 
+## Step 1c: Architecture Drift Check
+
+Verify that the implementation still matches the architecture doc's stated constraints and seam points.
+
+1. **Read the architecture doc** (`docs/architecture.md`) and identify 2-3 key architectural claims (format neutrality, seam points, abstraction boundaries, planned extensibility).
+2. **Spot-check each claim against the implementation:**
+   - Open the relevant source files and verify the claim holds.
+   - Example: if the architecture says "Core is format-neutral," check that core types don't contain format-specific units or concepts.
+   - Example: if the architecture says "the theme schema has a pptx: section," verify it actually exists.
+3. **Check ADR fitness functions:** If any ADRs in `docs/adrs/` have a "Fitness Functions" section, verify the checks listed there still pass.
+4. **Report findings** in the retro document:
+   - "**Architecture drift check:** X/Y claims verified. Z drift items found."
+   - For each drift item: which claim, what the code actually does, and severity.
+5. **Create `process-improvement` issues** for any drift found.
+
+**Why this step exists:** The 2026-03-15 retro found that DOCX-specific assumptions had leaked into format-neutral Core types over 11 sprints, despite the architecture doc explicitly planning for format neutrality. Architecture docs that aren't periodically validated against reality become fiction. This lightweight check (not a full audit) catches drift before it compounds.
+
+---
+
 ## Step 2: Backlog Sweep
 
 After the retro, sweep the entire backlog to catch orphaned or user-created issues:

--- a/docs/adrs/template.md
+++ b/docs/adrs/template.md
@@ -1,5 +1,5 @@
 ---
-agent-notes: { ctx: "ADR template for architectural decisions", deps: [CLAUDE.md], state: canonical, last: "archie@2026-02-12" }
+agent-notes: { ctx: "ADR template for architectural decisions", deps: [CLAUDE.md], state: canonical, last: "archie@2026-03-15" }
 ---
 
 # ADR-NNNN: <Title>
@@ -31,3 +31,10 @@ What becomes easier or more difficult to do because of this change?
 ### Neutral
 
 -
+
+## Fitness Functions
+
+How will we verify this decision continues to hold? Define concrete, observable checks that would catch a violation during code review or sprint boundary audits.
+
+- [ ] <check 1 — e.g., "No format-specific units in Md2.Core types">
+- [ ] <check 2 — e.g., "All IFormatEmitter implementations are in separate assemblies">

--- a/docs/process/done-gate.md
+++ b/docs/process/done-gate.md
@@ -3,7 +3,7 @@ agent-notes:
   ctx: "15-item Done Gate checklist for work items"
   deps: [CLAUDE.md]
   state: active
-  last: "coordinator@2026-03-11"
+  last: "grace@2026-03-15"
 ---
 # Done Gate — Detailed Checklist
 
@@ -32,3 +32,4 @@ Every work item must pass this gate before closing:
 15. **External integration smoke-tested** — if this work item integrates with external tools, services, or binaries (subprocess spawning, external APIs, CLI tool invocation), the happy path has been verified against the real tool, not just mocks. Mocked unit tests verify internal logic; this gate verifies the integration actually works end-to-end. If the external tool is unavailable in CI, document which manual verification was performed and by whom.
 16. **Composition coverage verified** — if the work item adds or modifies a *container* (table, list, blockquote) or an *inline* (bold, italic, link, code, strikethrough, image), integration tests must cover the cross-product of that feature with its peer features. Containers must be tested with every inline type inside them; new inline types must be tested inside every existing container. Unit tests on individual builders are necessary but not sufficient — they verify parts in isolation and miss composition bugs where one builder bypasses another's logic. See `docs/process/gotchas.md` § Testing Patterns for the composition matrix.
 17. **Showcase sample exercised** — if the work item changes rendering behavior, the project's representative sample document (e.g., `test-sample.md`) must be processed through the full pipeline and its output verified. The integration test suite's synthetic markdown is intentionally minimal; the showcase sample exercises real-world feature combinations that synthetic tests miss.
+18. **Architectural conformance verified** — if the work item touches shared/core types (types consumed by multiple emitters, shared abstractions, pipeline types), verify it doesn't introduce assumptions specific to one consumer/format. Check the relevant ADRs' fitness functions. Detection signal: format-specific units (twips, eighth-points), format-specific concepts (TOC, page margins), or format-specific markup (OMML) appearing in a shared type. See `docs/process/gotchas.md` § Architecture Patterns.

--- a/docs/process/gotchas.md
+++ b/docs/process/gotchas.md
@@ -3,7 +3,7 @@ agent-notes:
   ctx: "implementation gotchas and established patterns"
   deps: [CLAUDE.md]
   state: active
-  last: "grace@2026-03-12"
+  last: "grace@2026-03-15"
 ---
 # Known Patterns and Gotchas
 
@@ -47,9 +47,9 @@ Extracted from CLAUDE.md to reduce context window load. Read this when working o
 
 ## Architecture Patterns (Archie)
 
-<!-- Archie: add architectural constraints, integration point knowledge, and
-     schema evolution notes here. Patterns that informed past ADRs but aren't
-     worth a standalone ADR themselves. -->
+- **YAGNI vs. Planned Capabilities (the Drift Trap).** YAGNI says don't build abstractions for hypothetical futures. But when a future capability is architecturally planned (has an ADR, appears in the architecture doc, is on the roadmap), the abstraction boundary that enables it is a **current requirement**, not speculation. Using format-specific units in a shared type because "we only support DOCX today" is not YAGNI — it's tech debt against a planned capability. **Detection signal:** a shared/core type contains concepts specific to one consumer (twips, page margins, TOC options) while the architecture plans for multiple consumers. **Fix:** use format-neutral representations in shared types; format-specific conversions happen at the boundary (in the emitter, not in Core). See `docs/retrospectives/2026-03-15-architectural-drift-retro.md`.
+
+- **Architecture docs describe contracts, not aspirations.** If the architecture doc says "the theme schema has a `pptx:` section," that must be true in the code — not a commented-out placeholder. Treat architecture doc claims as testable assertions. When implementing, if you can't honor a stated constraint, update the architecture doc to reflect reality (mark it as deferred, not implemented). Don't leave the doc claiming something the code doesn't deliver.
 
 ## Adapter / Integration Gotchas
 

--- a/docs/process/team-governance.md
+++ b/docs/process/team-governance.md
@@ -3,7 +3,7 @@ agent-notes:
   ctx: "team roster, triggers, debate protocol, voice rules"
   deps: [CLAUDE.md, docs/methodology/personas.md, docs/methodology/phases.md]
   state: active
-  last: "coordinator@2026-03-13"
+  last: "grace@2026-03-15"
 ---
 # Team Governance
 
@@ -42,7 +42,7 @@ Match the situation to the right perspective:
 | Design decisions | **Dani** | Generate 2-3 sacrificial concepts before committing. |
 | Architecture / tech selection | **Archie** | ADR-driven trade-off analysis. Document the decision. |
 | Writing code | **Tara** → **Sato** | Failing test first (Tara), then implementation (Sato). Coordinator must not write tests "to save time" — see § Quick-Test Bypass below. |
-| Code review | **Vik** + **Tara** + **Pierrot** | Simplicity + perf, test coverage, security + compliance — three lenses. Plus migration safety (Archie) and API compat (Archie) when relevant. |
+| Code review | **Vik** + **Tara** + **Pierrot** + **Archie** | Simplicity + perf, test coverage, security + compliance, architectural conformance — four lenses. Plus migration safety (Archie) and API compat (Archie) when relevant. Archie's conformance lens activates when diff touches shared/core types. |
 | Reviewing work with the human | **Cam** (post-build) | Structured walkthrough. Translate vague reactions into actionable items. |
 | Any frontend/UI change | **Dani** (accessibility lens) | WCAG compliance, performance, responsive design. Non-negotiable for any component or CSS change. |
 | API contract changes | **Archie** (API lens) | API-first. Backward compatibility check. Versioning if breaking. |

--- a/docs/retrospectives/2026-03-15-architectural-drift-retro.md
+++ b/docs/retrospectives/2026-03-15-architectural-drift-retro.md
@@ -1,0 +1,79 @@
+---
+agent-notes:
+  ctx: "retro on DOCX assumptions leaking into format-neutral Core"
+  deps: [CLAUDE.md, docs/process/team-governance.md, docs/process/gotchas.md]
+  state: active
+  last: "grace@2026-03-15"
+---
+# Retrospective: Architectural Drift — DOCX Assumptions in Core
+
+**Date:** 2026-03-15
+**Scope:** Cross-sprint (Sprints 1–11)
+**Trigger:** PPTX v2 planning revealed format-specific assumptions baked into `Md2.Core`
+
+## Context
+
+During PPTX v2 planning, the team (Archie, Wei, Cam, Pat) analyzed the existing architecture for PPTX readiness. Despite the architecture doc (section 9) explicitly planning for PPTX with format-agnostic seam points, DOCX-specific assumptions had leaked into shared types throughout Sprints 1–11.
+
+**Evidence:**
+
+| File | DOCX-Specific Leakage |
+|------|-----------------------|
+| `ResolvedTheme.cs` | `BlockquoteIndentTwips`, `PageWidth`, `PageHeight`, `MarginTop/Bottom/Left/Right` — all DOCX units/concepts |
+| `EmitOptions.cs` | `IncludeToc`, `IncludeCoverPage`, `PageSize`, `Margins` — document-only concepts |
+| `ThemeDefinition.cs` | `Docx` property exists, no `Pptx` counterpart despite architecture doc claiming one |
+| `MathBlockAnnotator.cs` | Produces OMML (WordprocessingML format); PPTX needs DrawingML math |
+| `default.yaml` preset | `docx:` section only, no `pptx:` section despite architecture doc claiming it exists |
+
+## What Went Well
+
+1. **`IFormatEmitter` was built clean.** The top-level emitter interface is genuinely format-agnostic. The architectural seam exists where it was planned.
+2. **Transform pipeline is format-neutral.** AST transforms annotate via `SetData`/`GetData` and don't reference DOCX constructs directly (except math).
+3. **The team caught this during planning, not during implementation.** Wei's challenge session surfaced every leakage point before any PPTX code was written.
+
+## What Went Wrong
+
+### Finding 1: Architecture docs don't enforce themselves
+
+The architecture doc said "the architecture must not paint us into a corner" and described four PPTX seam points. But no mechanism existed to verify that the implementation honored these seams. `BlockquoteIndentTwips` went into `ResolvedTheme` in Sprint 1 and was never flagged.
+
+**Root cause:** Architecture was treated as a kickoff artifact, not a living constraint. No fitness function, checklist item, or review lens checked for architectural conformance during implementation.
+
+### Finding 2: YAGNI misapplied to planned capabilities
+
+During implementation sprints, using twips directly in `ResolvedTheme` was the simplest thing that worked. Abstracting to format-neutral units would have felt like over-engineering under YAGNI. But PPTX support wasn't speculative — it was architecturally planned from kickoff. The abstraction boundary was the requirement.
+
+**Root cause:** The team lacked a clear principle distinguishing "don't build for hypothetical futures" (YAGNI) from "maintain the abstraction boundary for planned capabilities."
+
+### Finding 3: No architectural conformance lens in code review
+
+The code-review process has three lenses: Vik (simplicity), Tara (testing), Pierrot (security). Plus situational lenses for Ines (operational), migration safety, and API compatibility. None of these check whether changes to shared types in Core introduce format-specific assumptions.
+
+**Root cause:** The review lenses were designed for general software quality, not for this project's specific architectural constraint (format neutrality in Core).
+
+### Finding 4: Architecture doc described intent as fact
+
+Section 9 of the architecture doc states "The theme schema already has a `pptx:` section." The YAML has a commented-out `# pptx:` placeholder. The doc describes aspiration as if it were implemented, and nobody caught the gap because the doc was never validated against the implementation.
+
+**Root cause:** Architecture docs are written once during kickoff and not re-validated at sprint boundaries. There is no "architecture drift check" in the sprint boundary workflow.
+
+## Recurring Issue Check
+
+Checked all 10 prior retros (`docs/retrospectives/`). No prior retro identified architectural conformance or format-specific drift as an issue. This is a **new finding**, not a recurring one.
+
+However, it rhymes with the Sprint 9 finding about the missing Wei debate for ADR-0012 — both are cases where the architecture gate process existed on paper but wasn't fully enforced. Sprint 10 addressed the Wei debate gap specifically, but the broader pattern (architecture intentions vs. implementation reality) was not generalized.
+
+## Architecture Gate Compliance
+
+**N/A** — This retro covers cross-sprint drift, not a specific sprint's gate compliance.
+
+## Actionable Changes
+
+| # | Change | Where | Issue |
+|---|--------|-------|-------|
+| 1 | Add "Architectural Conformance" as a code-review lens | `code-reviewer.md` agent, `code-review.md` skill, `team-governance.md` | Created |
+| 2 | Add Fitness Functions section to ADR template | `docs/adrs/template.md` | Created |
+| 3 | Add architecture drift check to sprint boundary | `.claude/commands/sprint-boundary.md` | Created |
+| 4 | Add YAGNI-vs-planned-capability guidance to gotchas | `docs/process/gotchas.md` | Created |
+| 5 | Add conformance review responsibility to Archie agent | `.claude/agents/archie.md` | Created |
+| 6 | Add architectural conformance item to Done Gate | `docs/process/done-gate.md` | Created |


### PR DESCRIPTION
## Summary

- Adds **Lens 4: Archie (Architectural Conformance)** to the code-reviewer agent and `/code-review` skill, triggered when diffs touch shared/core types
- Adds **Fitness Functions** section to the ADR template so architectural decisions include verifiable constraints
- Adds **Step 1c: Architecture Drift Check** to `/sprint-boundary` for periodic validation of architecture doc claims
- Adds **Done Gate #18** (architectural conformance verified) to the per-item checklist
- Adds **YAGNI vs. planned-capability** guidance and **architecture-docs-as-contracts** pattern to gotchas
- Adds conformance review responsibility to the Archie agent definition
- Updates team-governance persona triggers to include Archie in code review

Closes #99, #100, #101, #102

## Context

During PPTX v2 planning, the team discovered that DOCX-specific assumptions (twips, page margins, OMML math, TOC options) had leaked into `Md2.Core` shared types over 11 sprints, despite the architecture doc explicitly planning for format neutrality. No review lens, sprint check, or done gate item caught this drift.

## Test plan

- [ ] Verify `/code-review` skill includes Lens 4 when run against a diff touching Core types
- [ ] Verify ADR template includes Fitness Functions section
- [ ] Verify `/sprint-boundary` includes Step 1c
- [ ] Verify Done Gate lists item #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)